### PR TITLE
Add libsodium package to build and run images

### DIFF
--- a/stack/stack.toml
+++ b/stack/stack.toml
@@ -147,6 +147,7 @@ platforms = ["linux/amd64"]
     libsigc++-2.0-0v5:amd64 \
     libsigc++-2.0-dev \
     libsigsegv2 \
+    libsodium23 \
     libsqlite0 \
     libsqlite0-dev \
     libsqlite3-0 \
@@ -298,6 +299,7 @@ platforms = ["linux/amd64"]
     libselinux1 \
     libsigc++-2.0-0v5:amd64 \
     libsigsegv2 \
+    libsodium23 \
     libsqlite0 \
     libsqlite3-0 \
     libsysfs2 \

--- a/stack/stack.toml
+++ b/stack/stack.toml
@@ -148,6 +148,7 @@ platforms = ["linux/amd64"]
     libsigc++-2.0-dev \
     libsigsegv2 \
     libsodium23 \
+    libsodium-dev \
     libsqlite0 \
     libsqlite0-dev \
     libsqlite3-0 \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adding the libsodium23 package for libsodium support in addition to OpenSSL and other crypto libraries available in this package already.

## Use Cases
<!-- An explanation of the use cases your change enables -->

I'm coming from the Ruby world and was adding the popular [JWT gem](https://rubygems.org/gems/jwt) into my project, aiming to use the eliptic curve based ED25519 algorithm to signing JWT. This requires the [rbnacl](https://github.com/RubyCrypto/rbnacl) gem which uses the "libsodium" library provided by the operating system.

Looking into the list of libraries offered by the Heroku Buildpack, I [found the libsodium package](https://devcenter.heroku.com/articles/stack-packages#installed-ubuntu-packages) as well. So I was wondering if the paketo project would also like to offer libsodium by default.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
