### PR TITLE
Remove yj from build image.

### DIFF
--- a/stack/build.Dockerfile
+++ b/stack/build.Dockerfile
@@ -15,6 +15,4 @@ RUN echo "$sources" > /etc/apt/sources.list && \
   update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 && \
   apt-get -y $package_args install $packages && \
   rm -rf /var/lib/apt/lists/* /tmp/* /etc/apt/preferences && \
-  for path in /workspace /workspace/source-ws /workspace/source; do git config --system --add safe.directory "${path}"; done && \
-  curl -sL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux-amd64 && \
-  chmod +x /usr/local/bin/yj
+  for path in /workspace /workspace/source-ws /workspace/source; do git config --system --add safe.directory "${path}"; done


### PR DESCRIPTION
## Summary

This PR removes the `yj` binary in order to confirm with [RFC 0009](https://github.com/paketo-buildpacks/rfcs/blob/main/text/stacks/0009-remove-yj.md).

## Use Cases

See https://github.com/paketo-buildpacks/rfcs/issues/293.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
