### PR TITLE
Increase integration test timeout.

### DIFF
--- a/init_test.go
+++ b/init_test.go
@@ -25,6 +25,8 @@ func by(_ string, f func()) { f() }
 
 func TestAcceptance(t *testing.T) {
 	format.MaxLength = 0
+	SetDefaultEventuallyTimeout(30 * time.Second)
+
 	Expect := NewWithT(t).Expect
 
 	root, err := filepath.Abs(".")
@@ -35,8 +37,6 @@ func TestAcceptance(t *testing.T) {
 
 	stack.RunArchive = filepath.Join(root, "build", "run.oci")
 	stack.RunImageID = fmt.Sprintf("stack-run-%s", uuid.NewString())
-
-	SetDefaultEventuallyTimeout(10 * time.Second)
 
 	suite := spec.New("Acceptance", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Metadata", testMetadata)


### PR DESCRIPTION
## Summary

This PR increases the integration test timeout from 10 seconds to 30 seconds, as 10 seconds is not always sufficient to start a container in CI.

## Use Cases

Reduce flakiness in CI

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
